### PR TITLE
Allow form to be reverse proxied on subpath

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,7 +152,7 @@ async def index():
             return Response(response)
 
     form = f"""{error}<br />
-<form action="/" method="post">
+<form action="./" method="post">
     <label for="email">Your Podimo email address</label><br />
     <input type="email" required placeholder="Podimo email address" name="email"><br />
     <br />


### PR DESCRIPTION
Thanks for your project! Just tried to self-host this and it seems to work nicely with Pocket Casts now 👍 

I did need a small tweak to make it work behind a reverse proxy that hosted it on a subpath (e.g. https://example.com/podimo).

Without this, submitting the form doesn't work, because it always tries to POST to the `/` endpoint, which wouldn't be routed to the right endpoint in this situation.