### PR TITLE
Implement diskcache

### DIFF
--- a/podimo/cache.py
+++ b/podimo/cache.py
@@ -20,25 +20,26 @@
 from podimo.config import *
 from typing import Dict, Tuple
 from time import time
+from diskcache import Cache 
 
 # Store the authentication token in a dictionary
 # so it is not necessary to request a new token for every request. The key is
 # derived from the provided username and password (see the `token_key` function).
-TOKENS: Dict[str, Tuple[int, str]] = dict()
+TOKENS: Dict[str, Tuple[int, str]] = Cache(CACHE_DIR + 'tokens_cache')
 
 # Give each user its own cookie jar to keep track of cookies that are
 # being set and used between different requests.
-cookie_jars = dict()
+cookie_jars = Cache(CACHE_DIR + 'cookie_cache')
 
-url_cache = dict()
-podcast_cache = dict()
+url_cache = Cache(CACHE_DIR + 'url_cache')
+podcast_cache = Cache(CACHE_DIR + 'podcast_cache')
 
 # Podcast players support the display of the file size of each episode.
 # Podimo does not provide this information directly, so we do a HEAD request
 # to the episode file locations. This gives us the Content-Length which is
 # the file size of the episode. The file size of an episode doesn't change often,
 # which makes it perfect for caching.
-head_cache: Dict[str, Tuple[int, Tuple[str, str]]] = dict()
+head_cache: Dict[str, Tuple[int, Tuple[str, str]]] = Cache(CACHE_DIR + 'head_cache')
 
 def getCacheEntry(key: str, cache, delete=True):
     if key in cache:

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -19,16 +19,19 @@
 
 import os
 
-# You can overwrite the following three values with environmental variables
+# You can overwrite the following four values with environmental variables
 # - `PODIMO_HOSTNAME`: the hostname that is displayed to the user.
 #                      This defaults to "podimo.thijs.sh".
 # - `PODIMO_BIND_HOST`: to what IP and port the Python webserver should bind.
 #                       Defaults to "127.0.0.1:12104"
 # - `PODIMO_PROTOCOL`: what protocol is being used for all links that are
 #                      displayed to the user. Defaults to "https".
+# - `CACHE_DIR`:       where do we store the cache.
+#                      Defaults to "./cache/".
 PODIMO_HOSTNAME = os.environ.get("PODIMO_HOSTNAME", "podimo.thijs.sh")
 PODIMO_BIND_HOST = os.environ.get("PODIMO_BIND_HOST", "127.0.0.1:12104")
 PODIMO_PROTOCOL = os.environ.get("PODIMO_PROTOCOL", "https")
+CACHE_DIR = os.environ.get("CACHE_DIR", "./cache/")
 
 # Enable extra logging in debugging mode
 DEBUG = os.environ.get("DEBUG", False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ quart~=0.18.4
 hypercorn~=0.14.4
 cloudscraper~=1.2.71
 werkzeug~=2.3.7
+diskcache


### PR DESCRIPTION
Cache using standard dictionaries doesn't survive restart of the script. By writing cache to disk, we can reduce the number of queries to Cloudflare if tool is restarted regularly (eg if using Docker and experimenting with scrapers).