### PR TITLE
Added option to use local credentials

### DIFF
--- a/.block-list.example
+++ b/.block-list.example
@@ -1,0 +1,9 @@
+# This file contains the podfcast ID or the random 10 digit 
+# identifier added to the podcast feed URLs that you wanted blocked.
+# Create a new line for every feed you want to block
+1234567890
+abcdefghij
+
+# Emptry lines are ignored
+
+# de9b2081-9fc5-489f-b9d3-d744ed9cab20 # Uncheck to block "Man man man, de podcast" ;-)

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ README.md
 cache/**/*
 .env
 venv/**/*
+.block-list

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,22 @@ PODIMO_BIND_HOST="127.0.0.1:12104"
 #PODIMO_PROTOCOL="http"
 
 ###########
+# CREDENTIALS #
+###########
+# LOCAL_CREDENTIALS defines if credentials are stored on the local instance
+# instead of being sent to podcast client as part of the generated URL. 
+# This should be used by single-user instances only. It is *strongly* 
+# recommended to set this to false for shared instances.
+# - "false", the default. Credentials are part of the generate URL
+# - "true", more secure for single-user instances 
+#LOCAL_CREDENTIALS=false
+
+#Insert Podimo email and password here if using local credentials.
+#PODIMO_EMAIL="mijn_adres@email.com"
+#PODIMO_PASSWORD="1234"
+
+
+###########
 # PROXIES #
 ###########
 # If you run the service from a non-residential IP, or send more than

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 venv
 cache
 .env
+.block-list

--- a/main.py
+++ b/main.py
@@ -67,6 +67,7 @@ def allow_cors(response):
     response.headers.set('Access-Control-Allow-Origin', '*')
     response.headers.set('Access-Control-Allow-Methods', 'GET, POST')
     response.headers.set('Cache-Control', 'max-age=900')
+    logging.debug(f"Incoming {request.method} request for '{request.url}' from User-Agent {request.user_agent} at {request.remote_addr}.")
     return response
 
 def authenticate():
@@ -125,10 +126,11 @@ async def index():
         region = form.get("region")
         locale = form.get("locale")
 
-        if email is None or email == "":
-            error += "Email is required"
-        if password is None or password == "":
-            error += "Password is required"
+        if not LOCAL_CREDENTIALS:
+            if email is None or email == "":
+                error += "Email is required"
+            if password is None or password == "":
+                error += "Password is required"
         if podcast_id is None or podcast_id == "":
             error += "Podcast ID is required"
         elif podcast_id_pattern.fullmatch(podcast_id) is None:
@@ -143,26 +145,23 @@ async def index():
             error += "Locale is not valid"
 
         if error == "":
-            email = quote(str(email), safe="")
+            podcast_id = quote(str(podcast_id), safe="")
             region = quote(str(region), safe="")
             locale = quote(str(locale), safe="")
+            
+            if LOCAL_CREDENTIALS:
+                url = f"{PODIMO_PROTOCOL}://{PODIMO_HOSTNAME}/feed/{podcast_id}.xml?{randomHexId(10)}&region={region}&locale={locale}"
+            else:
+                email = quote(str(email), safe="")
+                comma = quote(',', safe="")
+                username = f"{email}{comma}{region}{comma}{locale}"
+                password = quote(str(password), safe="")             
+                url = f"{PODIMO_PROTOCOL}://{username}:{password}@{PODIMO_HOSTNAME}/feed/{podcast_id}.xml?{randomHexId(10)}&region={region}&locale={locale}"
+            
+            logging.debug(f"Created an URL: {url}.")
+            return await render_template("feed_location.html", url=url)
 
-            comma = quote(',', safe="")
-            username = f"{email}{comma}{region}{comma}{locale}"
-
-            password = quote(str(password), safe="")
-            podcast_id = quote(str(podcast_id), safe="")
-
-            return await render_template("feed_location.html", 
-                                         username=username,
-                                         password=password,
-                                         HOSTNAME=PODIMO_HOSTNAME,
-                                         PROTOCOL=PODIMO_PROTOCOL,
-                                         podcast_id=podcast_id,
-                                         random_id=randomHexId(10)
-            )
-
-    return await render_template("index.html", error=error, locales=LOCALES, regions=REGIONS)
+    return await render_template("index.html", error=error, locales=LOCALES, regions=REGIONS, need_credentials=not(LOCAL_CREDENTIALS))
 
 
 @app.errorhandler(404)
@@ -174,11 +173,18 @@ async def not_found(error):
 
 @app.route("/feed/<string:podcast_id>.xml")
 async def serve_basic_auth_feed(podcast_id):
-    auth = request.authorization
-    if not auth:
-        return authenticate()
+    if LOCAL_CREDENTIALS:
+        args = request.args
+        region = args.get("region")
+        locale = args.get("locale")
+        return await serve_feed(PODIMO_EMAIL, PODIMO_PASSWORD, podcast_id, region, locale)
     else:
-        return await serve_feed(auth.username, auth.password, podcast_id)
+        auth = request.authorization
+        if not auth:
+            return authenticate()
+        else:
+            username, region, locale = split_username_region_locale(auth.username)
+            return await serve_feed(username, auth.password, podcast_id, region, locale)
 
 
 def split_username_region_locale(string):
@@ -197,17 +203,18 @@ def token_key(username, password):
 
 
 @app.route("/feed/<string:username>/<string:password>/<string:podcast_id>.xml")
-async def serve_feed(username, password, podcast_id):
+async def serve_feed(username, password, podcast_id, region, locale):
     # Check if it is a valid podcast id string
     if podcast_id_pattern.fullmatch(podcast_id) is None:
         return Response("Invalid podcast id format", 400, {})
-
-    username, region, locale = split_username_region_locale(username)
+   
     if region not in [region_code for (region_code, _) in REGIONS]:
         return Response("Invalid region", 400, {})
     if locale not in LOCALES:
         return Response("Invalid locale", 400, {})
 
+    logging.debug(f"Feed request for podcast {podcast_id} from IP {request.remote_addr} with User-Agent:{request.user_agent}.")
+    
     with cloudscraper.create_scraper() as scraper:
         scraper.proxies = proxies
         client = await check_auth(username, password, region, locale, scraper)
@@ -355,6 +362,7 @@ if __name__ == "__main__":
         logging.info(f"""Spawning server on {PODIMO_BIND_HOST}
 Configuration: 
 - DEBUG: {DEBUG}
+- LOCAL CREDENTIALS: {LOCAL_CREDENTIALS} ({PODIMO_EMAIL})
 - PODIMO_HOSTNAME: {PODIMO_HOSTNAME}
 - PODIMO_BIND_HOST: {PODIMO_BIND_HOST}
 - PODIMO_PROTOCOL: {PODIMO_PROTOCOL}

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -46,6 +46,11 @@ CACHE_DIR = os.path.abspath(str(config.get("CACHE_DIR", "./cache")))
 # Enable extra logging in debugging mode
 DEBUG = bool(str(config.get("DEBUG", None)).lower() in ['true', '1', 't', 'y', 'yes'])
 
+# Enable local credentials
+LOCAL_CREDENTIALS = bool(str(config.get("LOCAL_CREDENTIALS", None)).lower() in ['true', '1', 't', 'y', 'yes'])
+PODIMO_EMAIL = config.get("PODIMO_EMAIL", None)
+PODIMO_PASSWORD = config.get("PODIMO_PASSWORD", None)
+
 # Podimo's API uses GraphQL. This variable defines the endpoint where
 # the API can be found.
 GRAPHQL_URL = "https://podimo.com/graphql"

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -42,6 +42,7 @@ HTTP_PROXY = config.get("HTTP_PROXY", None)
 ZENROWS_API = config.get("ZENROWS_API", None)
 SCRAPER_API = config.get("SCRAPER_API", None)
 CACHE_DIR = os.path.abspath(str(config.get("CACHE_DIR", "./cache")))
+BLOCK_LIST_FILE = str(config.get("BLOCK_LIST_FILE", "./.block-list"))
 
 # Enable extra logging in debugging mode
 DEBUG = bool(str(config.get("DEBUG", None)).lower() in ['true', '1', 't', 'y', 'yes'])
@@ -101,3 +102,14 @@ logging.basicConfig(
     datefmt="%Y-%m-%dT%H:%M:%SZ",
     level=log_level
 )
+
+# Load block list from file '.block-list' if it exists
+BLOCKED = set()
+if os.path.exists(BLOCK_LIST_FILE):
+    with open (BLOCK_LIST_FILE, 'r') as file:
+        for line in file:
+            line = line.strip()
+            if line and not line.startswith('#'): 
+                line = line.split(' ', 1)[0]
+                BLOCKED.add(line)
+#logging.debug(f'{BLOCKED}')  

--- a/templates/feed_location.html
+++ b/templates/feed_location.html
@@ -3,7 +3,7 @@
 {% block body %}
 Assuming your credentials were correct, your Podimo-to-RSS feed can be found at<br />
 <p>
-  {{ PROTOCOL }}://{{ username }}:{{ password }}@{{ HOSTNAME }}/feed/{{ podcast_id }}.xml?{{ random_id }}
+  {{ url }}
 </p>
 
 Copy this link into your podcast player (only works if it supports custom private RSS feeds).
@@ -12,7 +12,7 @@ Copy this link into your podcast player (only works if it supports custom privat
 
 <div id="button"></div>
 <script>
-  let url = "{{ PROTOCOL }}://{{ username }}:{{ password }}@{{ HOSTNAME }}/feed/{{ podcast_id }}.xml?{{ random_id }}"
+  let url = "{{ url }}"
   function copy() {
     navigator.clipboard.writeText(url).then(() => {
       document.getElementById('copy').innerHTML = "Copied!";

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,12 +24,14 @@ any normal podcast player.
 {% endif %}
 
 <form action="./" method="post">
+  {% if need_credentials %}
   <label for="email">Your Podimo email address</label> <br />
   <input type="email" required placeholder="Podimo email address" name="email" id="email"><br />
 
   <label for="password">Your Podimo password</label><br />
   <input type="password" required placeholder="Podimo password" name="password" id="password"><br />
-
+  {% endif %}
+  
   <label for="podcast_id">Podcast ID (https://open.podimo.com/podcast/<b>THIS IS THE ID</b>)</label><br />
   <input placeholder="Podcast ID" required name="podcast_id" id="podcast_id" pattern="[0-9a-fA-F\-]+"><br />
 


### PR DESCRIPTION
Hi Thijs, I created the option (off by default) to use local credentials (in .env file or other environment) instead of adding them to the URL and giving them to the podcast client. I think this is more secure (never felt really comfortable giving my login details to Pocket Cast) and, incidentally, should enable users to change Podimo login details without having to configure their favourite podcast player again. 