### PR TITLE
Optimise Docker build caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM python:3.10-alpine
 
-COPY . /src
-
 WORKDIR /src
 
+COPY requirements.txt /src/
 RUN apk add libxml2-dev libxslt-dev gcc libc-dev && pip3 install --no-cache-dir -r requirements.txt
+
+COPY . /src
 
 ENTRYPOINT [ "python3", "main.py" ]


### PR DESCRIPTION
Before `pip install`, only copy `requirements.txt`. That way, when changing `main.py` (or other files), the first stages remain cached by Docker layer caching.