### PR TITLE
Episode metadata improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -284,6 +284,7 @@ def extract_audio_url(episode):
 
 async def addFeedEntry(fg, episode, session, locale):
     fe = fg.add_entry()
+    fe.guid(episode["id"])
     fe.title(episode["title"])
     fe.description(episode["description"])
     fe.pubDate(episode["datetime"])

--- a/main.py
+++ b/main.py
@@ -288,6 +288,7 @@ async def addFeedEntry(fg, episode, session, locale):
     fe.title(episode["title"])
     fe.description(episode["description"])
     fe.pubDate(episode["publishDatetime"])
+    fe.podcast.itunes_image(episode["imageUrl"])
 
     url, duration = extract_audio_url(episode)
     if url is None:

--- a/main.py
+++ b/main.py
@@ -287,7 +287,7 @@ async def addFeedEntry(fg, episode, session, locale):
     fe.guid(episode["id"])
     fe.title(episode["title"])
     fe.description(episode["description"])
-    fe.pubDate(episode["datetime"])
+    fe.pubDate(episode["publishDatetime"])
 
     url, duration = extract_audio_url(episode)
     if url is None:

--- a/main.py
+++ b/main.py
@@ -336,7 +336,7 @@ async def podcastsToRss(podcast_id, data, locale):
         artist = podcast["authorName"]
         if artist is None:
             artist = last_episode["artist"]
-        fg.author({"name": artist})
+        fg.podcast.itunes_author(artist)
 
         if not PUBLIC_FEEDS:
             fg.podcast.itunes_block(True)

--- a/podimo/client.py
+++ b/podimo/client.py
@@ -194,6 +194,7 @@ class PodimoClient:
                 imageUrl
                 description
                 datetime
+                publishDatetime
                 title
                 audio {
                 url


### PR DESCRIPTION
I combined a few small improvements to the episode metadata in the feed in one PR, to not open too many separate PRs 😊

### Include stable episode IDs in feed (https://github.com/ThijsRay/podimo/commit/c453a569cc708754bfa72e4d9316a68dbe018912)

I’m not sure whether clients/players use it, but I presume a stable ID makes the feed more robust (like in cases when an episode title gets changed after publication).

### Use episode publish date-time in feed (https://github.com/ThijsRay/podimo/commit/11085a52a8c1e2169ab72fc3cce404b14253e420)

This seems more correct, as the feed should contain the publication date of the episode. I’m not sure what the original `datetime` from Podimo contains; perhaps it could be the date at which an episode was created in their backend (possibly before the actual publication)?

### Include episode image URLs in feed (https://github.com/ThijsRay/podimo/commit/33d7486f98eabd0dac1a3c106404273fd2ce6343)

Podimo returns an image URL for each episode, so why not include it in the feed?

### Use iTunes specific author tag in feed (https://github.com/ThijsRay/podimo/commit/e5f9d6daf49decdc545765dfd3764834237a010e)

The old approach of using the `author()` Feedgen method didn’t work, because it [requires an email address](https://python-feedgen.readthedocs.io/en/latest/api.feed.html#feedgen.feed.FeedGenerator.author):

> Get or set author data. An author element is a dictionary containing a name, an email address and a URI. Name is mandatory for ATOM, **email is mandatory for RSS**.

As no email address was supplied, this call was ignored by Feedgen and no `<author>` tag was present in the resulting feed.

However, we can use [`podcast.itunes_author()`](https://python-feedgen.readthedocs.io/en/latest/ext/api.ext.podcast.html#feedgen.ext.podcast.PodcastExtension.itunes_author) instead, which doesn’t require an email address and uses the `<itunes:author>` tag instead.