### PR TITLE
Adds rudimentary video support 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,7 +129,8 @@ DEBUG=true
 # Optionally, you can add a custom string to the title of podcasts that have 
 # a video version (that will be in the description). To do so, set the following
 # variable to the string you want to add (e.g. "(video available)").
-# VIDEO_TITLE_SUFFIX="(video available)"
+# Remember to add a space at the beginning of the string.
+# VIDEO_TITLE_SUFFIX=" (video available)"
 
 
 

--- a/.env.example
+++ b/.env.example
@@ -126,11 +126,17 @@ DEBUG=true
 # Enable this feature by setting the following variable to true.
 # ENABLE_VIDEO=false
 
+# Optionally, you can check if a podcast has a video version by making a 
+# request to the Podimo servers. This isn't properly tested and might slow
+# down the tool or break it.
+# Enable this feature by setting the following variable to true.
+# ENABLE_VIDEO_CHECK=false
+
 # Optionally, you can add a custom string to the title of podcasts that have 
 # a video version (that will be in the description). To do so, set the following
 # variable to the string you want to add (e.g. "(video available)").
 # Remember to add a space at the beginning of the string.
-# VIDEO_TITLE_SUFFIX=" (video available)"
+# VIDEO_TITLE_SUFFIX='(video available)'
 
 
 

--- a/.env.example
+++ b/.env.example
@@ -115,3 +115,21 @@ PODIMO_BIND_HOST="127.0.0.1:12104"
 # Enable extra logging in debugging mode
 # Set to false if you don't want to see as much information
 DEBUG=true
+
+#############
+##  VIDEO  ##
+#############
+# Experimental: enable rudimentary video support for video podcasts. 
+# This won't make the video available in your podcast app, but will add a link 
+# to the video (m3u8 stream) in the podcast description. 
+# This is a very experimental feature, may not work for all video podcasts.
+# Enable this feature by setting the following variable to true.
+# ENABLE_VIDEO=false
+
+# Optionally, you can add a custom string to the title of podcasts that have 
+# a video version (that will be in the description). To do so, set the following
+# variable to the string you want to add (e.g. "(video available)").
+# VIDEO_TITLE_SUFFIX="(video available)"
+
+
+

--- a/main.py
+++ b/main.py
@@ -308,9 +308,9 @@ async def addFeedEntry(fg, episode, session, locale):
     ep_id = url.split("/")[-1].replace(".mp3", "")
     hls_url = f"https://cdn.podimo.com/hls-media/{ep_id}/stream_video_high/stream.m3u8"
 
-    if video_exists_at_url(hls_url):
+    if VIDEO_ENABLED and video_exists_at_url(hls_url):
         fe.description(f"Video URL found at: {hls_url} (experimental) || {episode['description']}")
-        fe.title(episode["title"] + " (video available)")
+        fe.title(episode["title"] + VIDEO_TITLE_SUFFIX)
     else:
         fe.description(episode["description"])
         fe.title(episode["title"])

--- a/main.py
+++ b/main.py
@@ -300,13 +300,20 @@ async def addFeedEntry(fg, episode, session, locale):
     fe = fg.add_entry()
     fe.guid(episode["id"])
     fe.title(episode["title"])
-    fe.description(episode["description"])
-    fe.pubDate(episode.get("publishDatetime", episode.get("datetime")))
-    fe.podcast.itunes_image(episode["imageUrl"])
 
     url, duration = extract_audio_url(episode)
     if url is None:
-        return 
+        return
+
+    # Generate the video url and paste it as prefix in the description :')
+    ep_id = url.split("/")[-1].replace(".mp3", "")
+    hls_url = f"https://cdn.podimo.com/hls-media/{ep_id}/stream_video_high/stream.m3u8"
+    description = f"Video URL: {hls_url} (ymmv)             {episode['description']}"
+    fe.description(description)
+
+    fe.pubDate(episode.get("publishDatetime", episode.get("datetime")))
+    fe.podcast.itunes_image(episode["imageUrl"])
+
     logging.debug(f"Found podcast '{episode['title']}'")
     fe.podcast.itunes_duration(duration)
     content_length, content_type = await urlHeadInfo(session, episode['id'], url, locale)

--- a/main.py
+++ b/main.py
@@ -308,9 +308,17 @@ async def addFeedEntry(fg, episode, session, locale):
     ep_id = url.split("/")[-1].replace(".mp3", "")
     hls_url = f"https://cdn.podimo.com/hls-media/{ep_id}/stream_video_high/stream.m3u8"
 
-    if VIDEO_ENABLED and video_exists_at_url(hls_url):
-        fe.description(f"Video URL found at: {hls_url} (experimental) || {episode['description']}")
-        fe.title(episode["title"] + VIDEO_TITLE_SUFFIX)
+    if VIDEO_ENABLED:
+        if VIDEO_CHECK_ENABLED:
+            if video_exists_at_url(hls_url):
+                fe.description(
+                    f"Video URL found at: {hls_url} (experimental) || {episode['description']}"
+                )
+                fe.title(episode["title"] + VIDEO_TITLE_SUFFIX)
+            else:
+                fe.description(f"Video URL: {hls_url} (not verified) || {episode['description']}")
+                fe.title(episode["title"])
+
     else:
         fe.description(episode["description"])
         fe.title(episode["title"])

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -115,3 +115,10 @@ if os.path.exists(BLOCK_LIST_FILE):
             if line and not line.startswith('#'): 
                 line = line.split(' ', 1)[0]
                 BLOCKED.add(line)
+
+
+# load experimental video support env vars
+VIDEO_ENABLED = bool(
+    str(config.get("ENABLE_VIDEO", None)).lower() in ["true", "1", "t", "y", "yes"]
+)
+VIDEO_TITLE_SUFFIX = str(config.get("VIDEO_TITLE_SUFFIX", ""))

--- a/podimo/config.py
+++ b/podimo/config.py
@@ -121,4 +121,7 @@ if os.path.exists(BLOCK_LIST_FILE):
 VIDEO_ENABLED = bool(
     str(config.get("ENABLE_VIDEO", None)).lower() in ["true", "1", "t", "y", "yes"]
 )
+VIDEO_CHECK_ENABLED = bool(
+    str(config.get("ENABLE_VIDEO_CHECK", None)).lower() in ["true", "1", "t", "y", "yes"]
+)
 VIDEO_TITLE_SUFFIX = str(config.get("VIDEO_TITLE_SUFFIX", ""))

--- a/podimo/utils.py
+++ b/podimo/utils.py
@@ -70,7 +70,7 @@ def async_wrap(func):
         return await loop.run_in_executor(executor, pfunc)
     return run
 
-def video_exists_at(url: str) -> bool:
+def video_exists_at_url(url: str) -> bool:
     res = requests.get(url)
     if res.text.strip().startswith("#EXTM3U"):
         return True

--- a/podimo/utils.py
+++ b/podimo/utils.py
@@ -21,6 +21,7 @@ from email.utils import parseaddr
 from random import choice, randint
 from hashlib import sha256
 import asyncio
+import requests
 from functools import wraps, partial
 
 def randomHexId(length: int):
@@ -68,3 +69,9 @@ def async_wrap(func):
         pfunc = partial(func, *args, **kwargs)
         return await loop.run_in_executor(executor, pfunc)
     return run
+
+def video_exists_at(url: str) -> bool:
+    res = requests.get(url)
+    if res.text.strip().startswith("#EXTM3U"):
+        return True
+    return False


### PR DESCRIPTION
## Pull request type

- [ ] 🪳 Bugfix
- [ ] 👮🏻‍♂️ Security/dependency update
- [x] ✨ Feature (e.g., new script)
- [ ] 📝 Code style update (formatting, renaming)
- [ ] 🏗️ Refactoring (no functional changes, no API changes)
- [ ] 🔨 Build related changes (build scripts, build configs, etc.)
- [ ] 📘 Documentation

## Pull request description

Adds video support to the Thijstool in a very rudimentary way by manually recreating the URL from the episode ID and placing that in the description. Adds three new env vars:

- `ENABLE_VIDEO` enables this (pre-alpha) functionality
- `ENABLE_VIDEO_CHECK` enables functionality that makes a get request to the video url, only adding/marking if a video exists there
- `VIDEO_TITLE_SUFFIX` is a suffix that's added to podcast titles iff ENABLE_VIDEO and ENABLE_VIDEO_CHECK and the video URL refers to an actual video.
