### PR TITLE
Add noindex and nofollow

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 
 <head>
   <title>Podimo-to-RSS converter</title>
+  <meta name="robots" content="noindex, nofollow">
   <style>
     html {
       max-width: 80ch;


### PR DESCRIPTION
Since indexing the page is likely not desirable, it should be excluded from search results.